### PR TITLE
get-internal-imports: also include test dependencies

### DIFF
--- a/get-external-imports
+++ b/get-external-imports
@@ -15,4 +15,6 @@ if [ ! -f "$moduledir/go.mod" ]; then
 fi
 modname=$(awk '/^module / {print $2; exit}' "$moduledir/go.mod")
 cd "$moduledir"
-go list -f '{{ join .Imports "\n" }}' "./..." | LC_ALL=C sort -u | grep -v "$modname" | grep -Ev '^C$' > "$imported_packages"
+go list -f '{{ join .Imports "\n" }}{{ if .TestImports}}
+{{ join .TestImports "\n" }}{{ end }}{{ if .XTestImports}}
+{{ join .XTestImports "\n" }}{{ end }}' "./..." | LC_ALL=C sort -u | grep -v "$modname" | grep -Ev '^C$' > "$imported_packages"


### PR DESCRIPTION
Currently the cache won't include packages imported in test files, thus running such test will fail:

```
...
Running phase: checkPhase
evaling implicit 'preCheck' string hook
go: downloading go.uber.org/goleak v1.3.0
go: writing go.mod cache: mkdir /nix/store/f7lxsv036zi14jjf7xh6l2lxp75kbnwy-go-cache/go-mod-cache/cache/download/go.uber.org/goleak: permission denied
go: writing go.mod cache: mkdir /nix/store/f7lxsv036zi14jjf7xh6l2lxp75kbnwy-go-cache/go-mod-cache/cache/download/github.com/inconshreveable: permission denied
...
```

The missing packages can be added by including test dependencies in get-internal-import. While this adds to the number of packages that must be compiled for creating the cache, I'd expect the number of test-specific dependencies to be small for most projects.