### PR TITLE
buildGoCache: filter src with builtins.path, prevent rebuild

### DIFF
--- a/buildGoCache.nix
+++ b/buildGoCache.nix
@@ -14,10 +14,12 @@ assert (!(vendorHash != null && vendorEnv != null)); # vendorHash and vendorEnv 
 assert (vendorHash != null || vendorEnv != null); # one of vendorHash or vendorEnv must be set
 assert (proxyVendor -> vendorEnv == null); # proxyVendor is not compatible with vendorEnv
 let
-  filteredSource = builtins.filterSource
-    (path: type: type == "regular" && (baseNameOf path == "go.sum" || baseNameOf path == "go.mod"))
+  filteredSource = builtins.path {
+    path = src;
+    filter = path: type: type == "regular" && (baseNameOf path == "go.sum" || baseNameOf path == "go.mod" || baseNameOf path == "vendor");
+    name = "go-cache-src";
+  };
 
-    src;
   goModules =
     if vendorEnv == null then (buildGoModule {
       name = "deps";


### PR DESCRIPTION
This fixes a bug with the current filtering of src, which currently causes a rebuild on any change of the unfiltered source.

> Since filterSource uses the name of the input directory while naming the output directory, doing so will produce a directory name in the form of <hash2>-<hash>-<name>, where <hash>-<name> is the name of the input directory. Since <hash> depends on the unfiltered directory, the name of the output directory will indirectly depend on files that are filtered out by the function. This will trigger a rebuild even when a filtered out file is changed. Use builtins.path instead, which allows specifying the name of the output directory.

https://noogle.dev/f/builtins/filterSource

Thus switching to builtins.path, which seems to fix the issue.